### PR TITLE
Fix deprecated React method and add lint step to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,10 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       - run:
+          name: Lint
+          command: yarn lint
+
+      - run:
           name: Building site
           command: |
             if [ "${CIRCLE_BRANCH}" == "${PRODUCTION_BRANCH}" ]; then

--- a/app/assets/scripts/components/explore/dashboard/Filters.js
+++ b/app/assets/scripts/components/explore/dashboard/Filters.js
@@ -198,10 +198,10 @@ class ManualInput extends React.PureComponent {
     this.onFieldBlur = this.onFieldBlur.bind(this);
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (this.state.value !== nextProps.value) {
-      this.setState({ value: nextProps.value });
-    }
+  getDerivedStateFromProps (nextProps, prevState) {
+    if (prevState.value !== nextProps.value) {
+      return { value: nextProps.value };
+    } else return null;
   }
 
   onValueChange (e) {

--- a/app/assets/scripts/components/explore/dashboard/Filters.js
+++ b/app/assets/scripts/components/explore/dashboard/Filters.js
@@ -198,7 +198,7 @@ class ManualInput extends React.PureComponent {
     this.onFieldBlur = this.onFieldBlur.bind(this);
   }
 
-  getDerivedStateFromProps (nextProps, prevState) {
+  static getDerivedStateFromProps (nextProps, prevState) {
     if (prevState.value !== nextProps.value) {
       return { value: nextProps.value };
     } else return null;

--- a/app/assets/scripts/components/explore/dashboard/Filters.js
+++ b/app/assets/scripts/components/explore/dashboard/Filters.js
@@ -201,7 +201,9 @@ class ManualInput extends React.PureComponent {
   static getDerivedStateFromProps (nextProps, prevState) {
     if (prevState.value !== nextProps.value) {
       return { value: nextProps.value };
-    } else return null;
+    } else {
+      return null;
+    }
   }
 
   onValueChange (e) {


### PR DESCRIPTION
Changelog:

- Replace deprecated "componentWillReceiveProps" with "getDerivedStateFromProps"
- Add "Lint" step to CircleCI

This will enable lint checks before merging PRs.