### PR TITLE
Add decimal place to population chart

### DIFF
--- a/app/assets/scripts/components/explore/Charts.js
+++ b/app/assets/scripts/components/explore/Charts.js
@@ -200,37 +200,44 @@ class Charts extends Component {
               <dl className='chart-number-list'>
                 {data.appliedTechTypes.map(layerId => {
                   const techLayer = techLayers.find(l => l.id === layerId);
+
+                  // Add tech type if there is people connected or difference
+                  // between steps.
                   return (
-                    <Fragment key={layerId}>
-                      <dt>
-                        <span
-                          className='lgfx'
-                          style={{ backgroundColor: techLayer.color }}
-                        >
-                          {techLayer.label}
-                        </span>
-                      </dt>
-                      <dd>
-                        <span>
-                          {formatKeyIndicator(
-                            data.popConnected[layerId],
-                            'metric',
-                            1
-                          )}
-                        </span>
-                        {targetYear !== baseYear && (
-                          <small>
-                            {data.popConnectedDiff[layerId] > 0 && '+'}
+                    (data.popConnected[layerId] !== 0 ||
+                      (data.popConnectedDiff &&
+                        data.popConnectedDiff[layerId] !== 0)) && (
+                      <Fragment key={layerId}>
+                        <dt>
+                          <span
+                            className='lgfx'
+                            style={{ backgroundColor: techLayer.color }}
+                          >
+                            {techLayer.label}
+                          </span>
+                        </dt>
+                        <dd>
+                          <span>
                             {formatKeyIndicator(
-                              data.popConnectedDiff[layerId],
+                              data.popConnected[layerId],
                               'metric',
                               1
                             )}
-                            *
-                          </small>
-                        )}
-                      </dd>
-                    </Fragment>
+                          </span>
+                          {targetYear !== baseYear && (
+                            <small>
+                              {data.popConnectedDiff[layerId] > 0 && '+'}
+                              {formatKeyIndicator(
+                                data.popConnectedDiff[layerId],
+                                'metric',
+                                1
+                              )}
+                              *
+                            </small>
+                          )}
+                        </dd>
+                      </Fragment>
+                    )
                   );
                 })}
               </dl>

--- a/app/assets/scripts/components/explore/Charts.js
+++ b/app/assets/scripts/components/explore/Charts.js
@@ -187,8 +187,12 @@ class Charts extends Component {
                 <h1 className='popover__title'>Population connected</h1>
                 <p className='popover__subtitle'>
                   In {targetYear}:{' '}
-                  {formatKeyIndicator(data.pop - data.popUnconnected)} of{' '}
-                  {formatKeyIndicator(data.pop)}
+                  {formatKeyIndicator(
+                    data.pop - data.popUnconnected,
+                    'metric',
+                    1
+                  )}{' '}
+                  of {formatKeyIndicator(data.pop, 'metric', 1)}
                 </p>
               </div>
             </header>
@@ -208,15 +212,21 @@ class Charts extends Component {
                       </dt>
                       <dd>
                         <span>
-                          {formatKeyIndicator(data.popConnected[layerId])}
+                          {formatKeyIndicator(
+                            data.popConnected[layerId],
+                            'metric',
+                            1
+                          )}
                         </span>
                         {targetYear !== baseYear && (
                           <small>
                             {data.popConnectedDiff[layerId] > 0 && '+'}
                             {formatKeyIndicator(
-                              data.popConnectedDiff[layerId]
+                              data.popConnectedDiff[layerId],
+                              'metric',
+                              1
                             )}
-                              *
+                            *
                           </small>
                         )}
                       </dd>

--- a/app/assets/scripts/utils.js
+++ b/app/assets/scripts/utils.js
@@ -105,8 +105,10 @@ export function formatThousands (num, decimals = 2, forceDecimals = false) {
  *
  * @param {number} value The value to round
  * @param {string} type The type of indicator. One of: 'metric', 'power'
+ * @param {number} decimals Amount of decimals to keep. (Default: 0)
+ *
  */
-export function formatKeyIndicator (val, type) {
+export function formatKeyIndicator (val, type, decimals) {
   let unit;
   let divider;
   let digits = 1;
@@ -136,8 +138,8 @@ export function formatKeyIndicator (val, type) {
 
   unit = type === 'power' ? `${unit}W` : unit;
 
-  return `${isNeg ? '-' : ''}${Math.round(n / divider).toLocaleString('en-US', {
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits
+  return `${isNeg ? '-' : ''}${(n / divider).toLocaleString('en-US', {
+    minimumFractionDigits: typeof decimals === 'number' ? decimals : digits,
+    maximumFractionDigits: typeof decimals === 'number' ? decimals : digits
   })} ${unit}`;
 }


### PR DESCRIPTION
See #214.

In addition to adding one decimal place, tech types without people connected or difference between steps are not shown.

## Before

![precision-benin-before](https://user-images.githubusercontent.com/329694/65317935-addb8b80-db94-11e9-9da7-ee0f14e39928.gif)

## After

![precision-benin](https://user-images.githubusercontent.com/329694/65317950-b46a0300-db94-11e9-8682-c150c6c15606.gif)
