### PR TITLE
Add production deploy job to CircleCI workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,21 @@ jobs:
           command: yarn lint
 
       - run:
-          name: Building site
+          name: Building site production
           command: |
-            if [ "${CIRCLE_BRANCH}" == "${STAGING_BRANCH}" ] || [ "${CIRCLE_BRANCH}" == "${PRODUCTION_BRANCH}" ]; then
+            if [ "${CIRCLE_BRANCH}" == "${PRODUCTION_BRANCH}" ]; then
               yarn build           
             else
-              echo "Skip building site"
+              echo "Skip building production site"
+            fi
+
+      - run:
+          name: Building site staging
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "${STAGING_BRANCH}" ]; then
+              yarn stage           
+            else
+              echo "Skip building staging site"
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -30,14 +30,14 @@ jobs:
       - run:
           name: Building site
           command: |
-            if [ "${CIRCLE_BRANCH}" == "${STAGING_BRANCH}" ]; then
+            if [ "${CIRCLE_BRANCH}" == "${STAGING_BRANCH}" ] || [ "${CIRCLE_BRANCH}" == "${PRODUCTION_BRANCH}" ]; then
               yarn build           
             else
               echo "Skip building site"
             fi
 
       - run:
-          name: Deploy to Surge
+          name: Deploy to staging
           command: |
             if [ "${CIRCLE_BRANCH}" == "${STAGING_BRANCH}" ]; then
               cp ./dist/index.html ./dist/200.html
@@ -45,3 +45,32 @@ jobs:
             else
               echo "Not the branch you're looking for, skipping deploy"
             fi
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+              - dist
+            
+  deploy-production:
+    docker:
+      - image: 'circleci/python:3.7'
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Install awscli
+          command: sudo pip install awscli
+      - run:
+          name: Sync files at S3
+          command: aws s3 sync --delete /tmp/workspace/dist s3://${PRODUCTION_S3_BUCKET}/
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build
+      - deploy-production:
+          requires:
+            - build
+          filters:
+            branches:
+              only: enhance/production-deploy

--- a/app/assets/scripts/config/production.js
+++ b/app/assets/scripts/config/production.js
@@ -3,6 +3,7 @@
 export default {
   environment: 'production',
   // Change in index.html as well.
-  siteUrl: 'http://gep-explorer.surge.sh',
-  dataServiceUrl: 'http://gep-data-service.us-west-2.elasticbeanstalk.com'
+  siteUrl: 'https://electrifynow.info',
+  dataServiceUrl: 'https://gep-api-prod.us-west-2.elasticbeanstalk.com'
+
 };

--- a/app/assets/scripts/config/production.js
+++ b/app/assets/scripts/config/production.js
@@ -4,6 +4,5 @@ export default {
   environment: 'production',
   // Change in index.html as well.
   siteUrl: 'https://electrifynow.info',
-  dataServiceUrl: 'https://gep-api-prod.us-west-2.elasticbeanstalk.com'
-
+  dataServiceUrl: 'https://api.electrifynow.info'
 };

--- a/app/assets/scripts/config/staging.js
+++ b/app/assets/scripts/config/staging.js
@@ -1,5 +1,7 @@
 'use strict';
 
 export default {
-  environment: 'staging'
+  environment: 'staging',
+  siteUrl: 'http://gep-explorer.surge.sh',
+  dataServiceUrl: 'http://gep-data-service.us-west-2.elasticbeanstalk.com'
 };


### PR DESCRIPTION
This adds a CircleCI job for production deployment. Once it is clear from which bucket/beanstalk we are going to serve the production website, we should update the following:

- At CircleCI enviroment settings: 
  - AWS_ACCESS_KEY_ID
  - AWS_SECRET_ACCESS_KEY
  - PRODUCTION_BRANCH=master
  - PRODUCTION_S3_BUCKET;
- At explorer config files:
  - siteUrl
  - dataServiceUrl
