### PR TITLE
Add a page with relevant applications. Fix #247

### DIFF
--- a/app/assets/icons/collecticons/square--small.svg
+++ b/app/assets/icons/collecticons/square--small.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" id="icon-bound" fill="none" />
+  <rect x="4" y="4" width="8" height="8" />
+</svg>

--- a/app/assets/icons/collecticons/square.svg
+++ b/app/assets/icons/collecticons/square.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" id="icon-bound" fill="none" />
+  <rect x="2" y="2" width="12" height="12" />
+</svg>

--- a/app/assets/scripts/components/NavGlobalMenu.js
+++ b/app/assets/scripts/components/NavGlobalMenu.js
@@ -36,6 +36,16 @@ export default class NavGlobalMenu extends Component {
             <span>Explore</span>
           </NavLink>
         </li>
+        <li>
+          <NavLink
+            to='/relevant'
+            title='Relevant links and tools'
+            activeClassName='global-menu__link--active'
+            className='global-menu__link global-menu__link--default'
+          >
+            <span>Relevant tools</span>
+          </NavLink>
+        </li>
         {/* <li>
           <a
             href='https://link-to-docs'

--- a/app/assets/scripts/index.js
+++ b/app/assets/scripts/index.js
@@ -10,6 +10,7 @@ import config from './config';
 import Home from './views/Home';
 import Explore from './views/Explore';
 import About from './views/About';
+import Relevant from './views/Relevant';
 import SelectCountry from './views/SelectCountry';
 import SelectModel from './views/SelectModel';
 import UhOh from './views/UhOh';
@@ -27,6 +28,7 @@ ReactDOM.render(
         <Route exact path='/countries/:countryId/models' component={SelectModel} />
         <Route exact path='/explore/:modelId' component={Explore} />
         <Route exact path='/about' component={About} />
+        <Route exact path='/relevant' component={Relevant} />
         <Route path='*' component={UhOh} />
       </Switch>
     </Router>

--- a/app/assets/scripts/views/Relevant.js
+++ b/app/assets/scripts/views/Relevant.js
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+
+import App from './App';
+
+class Relevant extends Component {
+  render () {
+    return (
+      <App pageTitle='Relevant'>
+        <article className='inpage inpage--single inpage--related'>
+          <header className='inpage__header'>
+            <div className='inpage__subheader'>
+              <div className='inpage__headline'>
+                <h1 className='inpage__title'>Relevant tools</h1>
+              </div>
+            </div>
+          </header>
+          <div className='inpage__body'>
+            <div className='prose'>
+              <p>
+                Other applications and data sources that are relevant for the energy sector.
+              </p>
+              <dl className='dl--horizontal'>
+                <dt>
+                  <a href='https://energydata.info' target='_blank'>
+                    energydata.info
+                  </a>
+                </dt>
+                <dd>
+                  Open data and analytics for a sustainable energy future.
+                </dd>
+                <dt>
+                  <a href='https://globalsolaratlas.info' target='_blank'>
+                    Global Solar Atlas
+                  </a>
+                </dt>
+                <dd>
+                  Access to solar resource and photovoltaic power potential around the globe.
+                </dd>
+                <dt>
+                  <a href='https://globalwindatlas.info/' target='_blank'>
+                    Global Wind Atlas
+                  </a>
+                </dt>
+                <dd>
+                  Identify high-wind areas for wind power generation virtually anywhere in the world.
+                </dd>
+              </dl>
+            </div>
+          </div>
+        </article>
+      </App>
+    );
+  }
+}
+
+export default Relevant;

--- a/app/assets/styles/global/_page.scss
+++ b/app/assets/styles/global/_page.scss
@@ -132,6 +132,10 @@
   }
 }
 
+.global-menu__link--default::before {
+  @extend %collecticon-square;
+}
+
 .global-menu__link--home::before {
   @extend %collecticon-house;
 }


### PR DESCRIPTION
This PR adds a page with relevant applications:

![image](https://user-images.githubusercontent.com/751330/68497903-94190500-0223-11ea-80d4-55e7325a29ba.png)

It sets the square as the default navigation icon.