### PR TITLE
Add disclaimer in summary

### DIFF
--- a/app/assets/scripts/components/explore/Summary.js
+++ b/app/assets/scripts/components/explore/Summary.js
@@ -83,6 +83,13 @@ class Summary extends Component {
             <p className='exp-summary__subtitle'>
               Results for {this.props.appliedState.year}
             </p>
+            {model.disclaimer &&
+              <div className='exp-summary__disclaimer'>
+                <p>
+                  {model.disclaimer}
+                </p>
+              </div>
+            }
           </div>
         </header>
         <div className='exp-summary__body'>

--- a/app/assets/scripts/components/explore/Summary.js
+++ b/app/assets/scripts/components/explore/Summary.js
@@ -84,11 +84,9 @@ class Summary extends Component {
               Results for {this.props.appliedState.year}
             </p>
             {model.disclaimer &&
-              <div className='exp-summary__disclaimer'>
-                <p>
-                  {model.disclaimer}
-                </p>
-              </div>
+              <p className='exp-summary__disclaimer'>
+                {model.disclaimer}
+              </p>
             }
           </div>
         </header>

--- a/app/assets/styles/explore/_single.scss
+++ b/app/assets/styles/explore/_single.scss
@@ -363,6 +363,12 @@
   }
 }
 
+.exp-summary__headline {
+  > *:last-child {
+    margin-bottom: 0;
+  }
+}
+
 .exp-summary__title {
   @include heading(1rem);
   margin-bottom: 0;
@@ -373,7 +379,18 @@
   font-size: 0.75rem;
   line-height: 1rem;
   color: rgba($base-font-color, 0.64);
+  margin: 0 0 $global-spacing 0;
+}
+
+.exp-summary__disclaimer {
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: rgba($base-font-color, 0.64);
   margin: 0;
+  
+  > *:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .exp-summary__body {


### PR DESCRIPTION
Please, see https://github.com/global-electrification-platform/explorer/issues/204. 

Will display a paragraph from model `disclaimer` property. Example:

<img width="412" alt="Screenshot 2019-11-19 12 38 04" src="https://user-images.githubusercontent.com/329694/69149178-db2db280-0acd-11ea-8b82-7bd4c9d1cc82.png">

This depends on https://github.com/global-electrification-platform/data-service/pull/96.

cc @olafveerman 