### PR TITLE
Reinstate docs, update maps

### DIFF
--- a/app/assets/scripts/components/NavGlobalMenu.js
+++ b/app/assets/scripts/components/NavGlobalMenu.js
@@ -51,6 +51,7 @@ export default class NavGlobalMenu extends Component {
             href='https://gep-user-guide.readthedocs.io'
             target='_blank'
             title='Visit the documentation'
+            rel='noreferrer noopener'
             className='global-menu__link global-menu__link--docs'
           >
             <span>Documentation</span>

--- a/app/assets/scripts/components/NavGlobalMenu.js
+++ b/app/assets/scripts/components/NavGlobalMenu.js
@@ -46,16 +46,16 @@ export default class NavGlobalMenu extends Component {
             <span>Relevant tools</span>
           </NavLink>
         </li>
-        {/* <li>
+        <li>
           <a
-            href='https://link-to-docs'
+            href='https://gep-user-guide.readthedocs.io'
             target='_blank'
             title='Visit the documentation'
             className='global-menu__link global-menu__link--docs'
           >
             <span>Documentation</span>
           </a>
-        </li> */}
+        </li>
         <li>
           <NavLink
             to='/about'

--- a/app/assets/scripts/components/explore/Map.js
+++ b/app/assets/scripts/components/explore/Map.js
@@ -6,7 +6,7 @@ import bbox from '@turf/bbox';
 import { PropTypes as T } from 'prop-types';
 
 import MapPopover from './connected/MapPopover';
-import { mapboxAccessToken, environment } from '../../config';
+import { mapboxAccessToken, environment, basemapStyleLink } from '../../config';
 import MapboxControl from '../MapboxReactControl';
 import LayerControlDropdown from './MapLayerControl';
 
@@ -118,7 +118,7 @@ class Map extends React.Component {
 
     this.map = new mapboxgl.Map({
       container: this.refs.mapEl,
-      style: 'mapbox://styles/devseed/cjpbi9n1811yd2snwl9ezys5p',
+      style: basemapStyleLink,
       bounds: bounds,
       preserveDrawingBuffer: true
     });

--- a/app/assets/scripts/config.js
+++ b/app/assets/scripts/config.js
@@ -31,6 +31,7 @@ if (process.env.DS_ENV === 'staging') {
 }
 
 config.default.mapboxAccessToken = process.env.MB_TOKEN || config.default.mapboxAccessToken;
+config.default.basemapStyleLink = process.env.BASEMAP_STYLE_LINK || config.default.basemapStyleLink;
 config.default.dataServiceUrl = process.env.API || config.default.dataServiceUrl;
 
 // The require doesn't play super well with es6 imports. It creates an internal

--- a/app/assets/scripts/config/defaults.js
+++ b/app/assets/scripts/config/defaults.js
@@ -7,5 +7,6 @@ export default {
     'Explore least cost electrification strategies around the world.',
   baseUrl: 'http://localhost:9000',
   dataServiceUrl: 'http://localhost:3000',
-  mapboxAccessToken: null
+  mapboxAccessToken: null,
+  basemapStyleLink: 'mapbox://styles/devseed/cjpbi9n1811yd2snwl9ezys5p'
 };


### PR DESCRIPTION
Changes in this PR:

- Reinstate docs link #248
- Make base map configurable via enviroment variables

@EricSoroos I'm keeping the current basemap style link for development purposes. Once this PR is merged and released, you will be able to change it via `BASEMAP_STYLE_LINK` enviroment variable during build time. 